### PR TITLE
Persist selected file and content across browser refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,14 @@ interface MyDB extends DBSchema {
 
 const App: React.FC = () => {
   const [uploadedFiles, setUploadedFiles] = useState<{ name: string; content: string }[]>([]);
-  const [selectedFileContent, setSelectedFileContent] = useState<string>('// Enter Antimony Model Here');
+  const [selectedFileContent, setSelectedFileContent] = useState<string>(
+    window.localStorage.getItem('current_file') || '// Enter Antimony Model Here'
+  );
   const [selectedFileName, setSelectedFileName] = useState<string>('');
   const [db, setDb] = useState<IDBPDatabase<MyDB> | null>();
+  const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(
+    Number(window.localStorage.getItem('current_file_index') || null)
+  );
 
   useEffect(() => {
     openDB<MyDB>('antimony_editor_db', 1, {
@@ -59,6 +64,23 @@ const App: React.FC = () => {
       db.put('files', { name: fileName, content: fileContent });
     }
   };
+
+  useEffect(() => {
+    openDB<MyDB>('antimony_editor_db', 1, {
+      upgrade(db) {
+      },
+    }).then(database => {
+      setDb(database);
+      database.getAll('files').then(files => {
+        setUploadedFiles(files);
+        // Set the selected file content based on the stored index
+        if (selectedFileIndex !== null && files[selectedFileIndex]) {
+          setSelectedFileContent(files[selectedFileIndex].content);
+          setSelectedFileName(files[selectedFileIndex].name);
+        }
+      });
+    });
+  }, [selectedFileIndex]);
 
   return (
     <div className='app'>

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './FileExplorer.css'
 
 interface FileExplorerProps {
@@ -7,7 +7,9 @@ interface FileExplorerProps {
 }
 
 const FileExplorer: React.FC<FileExplorerProps> = ({ files, onFileClick }) => {
-  const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(null);
+  const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(
+    Number(window.localStorage.getItem('current_file_index') || null)
+  );
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
 
   const handleFileButtonClick = (index: number, fileName: string) => {
@@ -15,6 +17,22 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ files, onFileClick }) => {
     setSelectedFileName(fileName)
     onFileClick(files[index].content, fileName);
   };
+
+  useEffect(() => {
+    const fileIndex = window.localStorage.getItem('current_file_index');
+    if (fileIndex !== null) {
+      const index = Number(fileIndex);
+      if (!isNaN(index) && index >= 0 && index < files.length) {
+        setSelectedFileIndex(index);
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (selectedFileIndex !== null) {
+      window.localStorage.setItem('current_file_index', String(selectedFileIndex));
+    }
+  }, [selectedFileIndex])
 
   return (
     <div className="file-explorer">


### PR DESCRIPTION
I store the selected file index to local storage using useEffect in the file explorer and then get the index stored in the local storage to get the content from the selected file. This keeps the selected file highlighted and its contents on the screen even if the page refreshes. 