### PR TITLE
Change to highlight style rather than squiggly underline

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/AntimonyEditor.iml
+++ b/.idea/AntimonyEditor.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/AntimonyEditor.iml" filepath="$PROJECT_DIR$/.idea/AntimonyEditor.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,9 +7843,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001579",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+      "version": "1.0.30001639",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
+      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/components/antimony-editor/AntimonyEditor.tsx
+++ b/src/components/antimony-editor/AntimonyEditor.tsx
@@ -7,7 +7,7 @@ import "./AntimonyEditor.css";
 import { getBiomodels, getModel } from "../../features/BrowseBiomodels";
 import Loader from "../Loader";
 import CreateAnnotationModal from "../create-annotation/CreateAnnotationModal";
-import ModelSemanticsChecker from "../../language-handler/ModelSemanticChecker";
+import ModelSemanticsChecker from "../../language-handler/model-semantic-checker/ModelSemanticChecker";
 import { IDBPDatabase, DBSchema } from "idb";
 import { SrcPosition, SrcRange } from "../../language-handler/Types";
 

--- a/src/language-handler/AntimonyTheme.ts
+++ b/src/language-handler/AntimonyTheme.ts
@@ -34,6 +34,6 @@ export const antimonyTheme: monaco.editor.IStandaloneThemeData = {
       { token: 'comment', foreground: '#76B947' },
       { token: 'string', foreground: '#f2ab7c' },
       { token: 'number', foreground: '#def9cb' },
-      { token: 'connected-parentheses', foreground: '#ffe628' },
+      { token: 'connected-parentheses', foreground: '#ffe628' }
     ],
 };

--- a/src/language-handler/model-semantic-checker/ModelSemanticChecker.css
+++ b/src/language-handler/model-semantic-checker/ModelSemanticChecker.css
@@ -1,0 +1,3 @@
+.unannotated-variable {
+  background-color: #FF0000;
+}

--- a/src/language-handler/model-semantic-checker/ModelSemanticChecker.ts
+++ b/src/language-handler/model-semantic-checker/ModelSemanticChecker.ts
@@ -6,13 +6,14 @@ import {
   RecognitionException,
   Recognizer,
 } from "antlr4ts";
-import { AntimonyGrammarLexer } from "./antlr/AntimonyGrammarLexer";
-import { AntimonyGrammarParser, RootContext } from "./antlr/AntimonyGrammarParser";
-import { GlobalST, ParamAndNameTable } from "./SymbolTableClasses";
-import { SymbolTableVisitor } from "./SymbolTableVisitor";
-import { SemanticVisitor } from "./SemanticVisitor";
-import { ErrorUnderline, SrcPosition, SrcRange, isSubtTypeOf, varTypes } from "./Types";
-import { Variable } from "./Variable";
+import { AntimonyGrammarLexer } from ".././antlr/AntimonyGrammarLexer";
+import { AntimonyGrammarParser, RootContext } from ".././antlr/AntimonyGrammarParser";
+import { GlobalST, ParamAndNameTable } from ".././SymbolTableClasses";
+import { SymbolTableVisitor } from ".././SymbolTableVisitor";
+import { SemanticVisitor } from ".././SemanticVisitor";
+import { ErrorUnderline, SrcPosition, SrcRange, isSubtTypeOf, varTypes } from ".././Types";
+import { Variable } from ".././Variable";
+import "./ModelSemanticChecker.css"
 
 /**
  * Defines a parse error, which includes a position (line, column) as well as the error message.
@@ -64,7 +65,8 @@ export const ModelSemanticsChecker = (
 
   // Get all unannotated variables (optional)
   if (annotHighlightOn) {
-    errors = errors.concat(antAnalyzer.getUnannotatedVariables());
+    const unannotatedDecorations = antAnalyzer.getUnannotatedDecorations();
+    editor.deltaDecorations([], unannotatedDecorations);
   }
 
   if (setGeneralHoverInfo) {
@@ -449,6 +451,30 @@ export class AntimonyProgramAnalyzer {
     }
 
     return errors;
+  }
+
+  /**
+   * Retrieves decorations for unannotated variables in a Monaco editor instance.
+   * Each decoration marks specific ranges where unannotated variables are referenced.
+   * @returns An array of Monaco editor decorations (`monaco.editor.IModelDeltaDecoration`).
+   */
+  getUnannotatedDecorations(): monaco.editor.IModelDeltaDecoration[] {
+      const unannotatedErrors: ErrorUnderline[] = this.getUnannotatedVariables();
+      const decorations: monaco.editor.IModelDeltaDecoration[] = unannotatedErrors.map(error => {
+          return {
+              range: new monaco.Range(
+                  error.startLineNumber,
+                  error.startColumn,
+                  error.endLineNumber,
+                  error.endColumn
+              ),
+              options: {
+                  inlineClassName: 'unannotated-variable', // Custom class for unannotated variables
+                  stickiness: monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges
+              }
+          };
+      });
+      return decorations;
   }
 
   /**

--- a/src/testing/App.test.tsx
+++ b/src/testing/App.test.tsx
@@ -3,7 +3,7 @@ import * as monaco from 'monaco-editor';
 import * as fs from 'fs';
 import { join } from 'path';
 import { isSubtTypeOf, varTypes } from '../language-handler/Types';
-import { AntimonyProgramAnalyzer } from '../language-handler/ModelSemanticChecker';
+import { AntimonyProgramAnalyzer } from '../language-handler/model-semantic-checker/ModelSemanticChecker';
 import { searchOntology, searchRhea } from '../features/AnnotationSearch';
 
 // test('renders learn react link', () => {


### PR DESCRIPTION
Updated the styling of unannotated variables to use a highlighting effect instead of the previous red squiggly underline. This enhances visibility and clarity for identifying unannotated variables within the editor.