### PR TITLE
Add feature for deleting ambiguous options (remove button)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,9 +33,12 @@ export interface MyDB extends DBSchema {
  * @returns - App component
  */
 const App: React.FC = () => {
-  const [uploadedFiles, setUploadedFiles] = useState<{ name: string; content: string }[]>([]);
+  const [uploadedFiles, setUploadedFiles] = useState<
+    { name: string; content: string }[]
+  >([]);
   const [selectedFileContent, setSelectedFileContent] = useState<string>(
-    window.localStorage.getItem("current_file") || "// Enter Antimony Model Here"
+    window.localStorage.getItem("current_file") ||
+      "// Enter Antimony Model Here"
   );
   const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(
     Number(window.localStorage.getItem("current_file_index") || null)
@@ -44,13 +47,11 @@ const App: React.FC = () => {
     window.localStorage.getItem("current_file_name") || "untitled.ant"
   );
   const [db, setDb] = useState<IDBPDatabase<MyDB> | null>();
-  const [editorInstance, setEditorInstance] = useState<monaco.editor.IStandaloneCodeEditor | null>(
-    null
-  );
+  const [editorInstance, setEditorInstance] =
+    useState<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [fileExplorerKey, setFileExplorerKey] = useState<number>(0);
-  const [selectedEditorPosition, setSelectedEditorPosition] = useState<SrcPosition>(
-    new SrcPosition(1, 1)
-  );
+  const [selectedEditorPosition, setSelectedEditorPosition] =
+    useState<SrcPosition>(new SrcPosition(1, 1));
   // keep track in App so that the option persists across different files.
   const [annotUnderlinedOn, setAnnotUnderlinedOn] = useState<boolean>(false);
 
@@ -87,14 +88,19 @@ const App: React.FC = () => {
    * @description Handle the file upload
    * @param event - The event
    */
-  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const files = event.target.files;
     if (files && db) {
       Array.from(files).forEach(async (file) => {
         const reader = new FileReader();
         reader.readAsText(file);
         reader.onload = async () => {
-          const fileData = { name: file.name, content: reader.result as string };
+          const fileData = {
+            name: file.name,
+            content: reader.result as string,
+          };
           await db.put("files", fileData);
           setUploadedFiles((prevFiles) => {
             const updatedFiles = [...prevFiles, fileData];
@@ -123,7 +129,11 @@ const App: React.FC = () => {
    * @param fileName - The name of the file
    * @param index - The index of the file
    */
-  const handleFileClick = (fileContent: string, fileName: string, index: number) => {
+  const handleFileClick = (
+    fileContent: string,
+    fileName: string,
+    index: number
+  ) => {
     window.localStorage.setItem("current_file_index", index.toString());
     window.localStorage.setItem("current_file_name", fileName);
     window.localStorage.setItem("current_file", fileContent);
@@ -137,15 +147,21 @@ const App: React.FC = () => {
   const handleConversionAntimony = () => {
     try {
       if (db) {
-        db.transaction("files").objectStore("files").get(selectedFileName).then((data) => {
-          if (data) {
-            if (window.convertAntimonyToSBML) {
-              window.convertAntimonyToSBML(data.content).then((converted) => {
-                handleNewFile(selectedFileName.replace("ant", "xml"), converted);
-              })
+        db.transaction("files")
+          .objectStore("files")
+          .get(selectedFileName)
+          .then((data) => {
+            if (data) {
+              if (window.convertAntimonyToSBML) {
+                window.convertAntimonyToSBML(data.content).then((converted) => {
+                  handleNewFile(
+                    selectedFileName.replace("ant", "xml"),
+                    converted
+                  );
+                });
+              }
             }
-          }
-        });
+          });
       } else {
         console.log("DB is null");
       }
@@ -160,15 +176,21 @@ const App: React.FC = () => {
   const handleConversionSBML = () => {
     try {
       if (db) {
-        db.transaction("files").objectStore("files").get(selectedFileName).then((data) => {
-          if (data) {
-            if (window.convertSBMLToAntimony) {
-              window.convertSBMLToAntimony(data.content).then((converted) => {
-                handleNewFile(selectedFileName.replace("xml", "ant"), converted);
-              })
+        db.transaction("files")
+          .objectStore("files")
+          .get(selectedFileName)
+          .then((data) => {
+            if (data) {
+              if (window.convertSBMLToAntimony) {
+                window.convertSBMLToAntimony(data.content).then((converted) => {
+                  handleNewFile(
+                    selectedFileName.replace("xml", "ant"),
+                    converted
+                  );
+                });
+              }
             }
-          }
-        });
+          });
       } else {
         console.log("DB is null");
       }
@@ -185,7 +207,9 @@ const App: React.FC = () => {
       setUploadedFiles(files);
 
       // Update selectedFileIndex based on the current files
-      const fileIndex = Number(window.localStorage.getItem("current_file_index"));
+      const fileIndex = Number(
+        window.localStorage.getItem("current_file_index")
+      );
       if (fileIndex >= 0 && fileIndex < files.length) {
         setSelectedFileIndex(fileIndex);
         setSelectedFileContent(files[fileIndex].content);
@@ -193,7 +217,7 @@ const App: React.FC = () => {
       } else {
         setSelectedFileIndex(null);
         setSelectedFileContent("// Enter Antimony Model Here");
-        setSelectedFileContent("")
+        setSelectedFileContent("");
         setSelectedFileName("untitled.ant");
         window.localStorage.removeItem("current_file_index");
       }
@@ -207,12 +231,17 @@ const App: React.FC = () => {
    * @param fileName - The name of the file to delete
    * @param deleteFromFileExplorer - Represents whether to delete the file from the file explorer
    */
-  const deleteFile = async (fileName: string, deleteFromFileExplorer: boolean) => {
+  const deleteFile = async (
+    fileName: string,
+    deleteFromFileExplorer: boolean
+  ) => {
     if (db) {
       await db.delete("files", fileName); // Delete from IndexedDB
 
       if (deleteFromFileExplorer) {
-        const updatedFiles = uploadedFiles.filter((file) => file.name !== fileName);
+        const updatedFiles = uploadedFiles.filter(
+          (file) => file.name !== fileName
+        );
         setUploadedFiles(updatedFiles);
 
         // NOTE: Currently, a file is selected before it is deleted.
@@ -227,7 +256,11 @@ const App: React.FC = () => {
         } else if (selectedFileIndex === updatedFiles.length) {
           // If the selected file is deleted and was the last file, select the file before it.
           const newIndex = selectedFileIndex - 1;
-          handleFileClick(updatedFiles[newIndex].content, updatedFiles[newIndex].name, newIndex);
+          handleFileClick(
+            updatedFiles[newIndex].content,
+            updatedFiles[newIndex].name,
+            newIndex
+          );
         } else {
           // If the selected file is deleted, select the file now in its place.
           handleFileClick(
@@ -252,14 +285,17 @@ const App: React.FC = () => {
    * @param newFileName - The name of the new file
    */
   const handleNewFile = async (newFileName: string, fileContent: string) => {
-    const newFileContent = (fileContent === "" ? "// Enter Antimony Model Here" : fileContent);
-    const file = new File([newFileContent], newFileName, { type: "text/plain" });
+    const newFileContent =
+      fileContent === "" ? "// Enter Antimony Model Here" : fileContent;
+    const file = new File([newFileContent], newFileName, {
+      type: "text/plain",
+    });
     const dataTransfer = new DataTransfer();
 
     dataTransfer.items.add(file);
 
     if (db) {
-      let fileobj = {name: newFileName, content: newFileContent};
+      let fileobj = { name: newFileName, content: newFileContent };
 
       // Add file to database
       await db.put("files", fileobj);
@@ -278,6 +314,35 @@ const App: React.FC = () => {
       handleFileClick(newFileContent, newFileName, newFileIndex);
     } else {
       console.log("Database is null! File was not added");
+    }
+  };
+
+  /**
+   * @description Removes the file from the file explorer menu only
+   * @param fileName - The name of the file to remove
+   */
+  const removeFileFromMenu = (fileName: string) => {
+    const updatedFiles = uploadedFiles.filter((file) => file.name !== fileName);
+    setUploadedFiles(updatedFiles);
+
+    // Handle selection after removal similar to delete
+    if (selectedFileIndex === null || updatedFiles.length === 1) {
+      handleNewFile("untitled.ant", "");
+    } else if (selectedFileIndex === 1) {
+      handleFileClick(updatedFiles[1].content, updatedFiles[1].name, 1);
+    } else if (selectedFileIndex === updatedFiles.length) {
+      const newIndex = selectedFileIndex - 1;
+      handleFileClick(
+        updatedFiles[newIndex].content,
+        updatedFiles[newIndex].name,
+        newIndex
+      );
+    } else {
+      handleFileClick(
+        updatedFiles[selectedFileIndex].content,
+        updatedFiles[selectedFileIndex].name,
+        selectedFileIndex
+      );
     }
   };
 
@@ -315,6 +380,7 @@ const App: React.FC = () => {
               setFiles={setUploadedFiles}
               onFileClick={handleFileClick}
               onDeleteFile={deleteFile}
+              onRemoveFile={removeFileFromMenu}
               selectedFileIndex={selectedFileIndex}
               setSelectedFileIndex={setSelectedFileIndex}
               selectedFileName={selectedFileName}
@@ -346,11 +412,16 @@ const App: React.FC = () => {
       </div>
       <footer>
         <div className="footer-content">
-          <a target="_blank" rel="noopener noreferrer" href="https://reproduciblebiomodels.org/">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://reproduciblebiomodels.org/"
+          >
             Copyright © 2024 Center for Reproducible Biomedical Modeling
           </a>
           <div className="selected-editor-position">
-            Ln {selectedEditorPosition.line}, Col {selectedEditorPosition.column}
+            Ln {selectedEditorPosition.line}, Col{" "}
+            {selectedEditorPosition.column}
           </div>
         </div>
       </footer>

--- a/src/components/context-menu/ContextMenu.tsx
+++ b/src/components/context-menu/ContextMenu.tsx
@@ -13,6 +13,7 @@ const ContextMenu = React.forwardRef<HTMLDivElement, ContextMenuProps>(
       <div className="context-menu" style={{ top: y, left: x }} ref={ref}>
         <ul>
           <li onClick={() => onOptionClick("rename")}>Rename</li>
+          <li onClick={() => onOptionClick("remove")}>Remove</li>
           <li onClick={() => onOptionClick("delete")}>Delete</li>
         </ul>
       </div>

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -14,6 +14,7 @@ import ContextMenu from "../context-menu/ContextMenu";
  * @property {string} onFileClick[].fileName - The name of the file
  * @property {string} onFileClick[].index - The index of the file
  * @property {function} onDeleteFile - The onDeleteFile function that deletes the given file
+ * @property {function} onRemoveFile - The onRemoveFile function that removes the given file from the file explorer
  * @property {number | null} selectedFileIndex - The index of the currently selected file
  * @property {function} setSelectedFileIndex - The function to set the selectedFileIndex
  * @property {string} selectedFileName - The name of the currently selected file
@@ -25,6 +26,7 @@ interface FileExplorerProps {
   setFiles: React.Dispatch<React.SetStateAction<{ name: string; content: string }[]>>;
   onFileClick: (fileContent: string, fileName: string, index: number) => void;
   onDeleteFile: (fileName: string, deleteFromFileExplorer: boolean) => Promise<void>;
+  onRemoveFile: (fileName: string) => void;
   selectedFileIndex: number | null;
   setSelectedFileIndex: React.Dispatch<React.SetStateAction<number | null>>;
   selectedFileName: string;
@@ -37,6 +39,7 @@ interface FileExplorerProps {
  * @param setFiles - FileExplorerProp
  * @param onFileClick - FileExplorerProp
  * @param onDeleteFile - FileExplorerProp
+ * @param onRemoveFile - FileExplorerProp
  * @param selectedFileIndex - FileExplorerProp
  * @param setSelectedFileIndex - FileExplorerProp
  * @param selectedFileName - FileExplorerProp
@@ -48,6 +51,7 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
   setFiles,
   onFileClick,
   onDeleteFile,
+  onRemoveFile,
   selectedFileIndex,
   setSelectedFileIndex,
   selectedFileName,
@@ -168,6 +172,15 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
       setNewFileName(selectedFileName);
     } else if (option === "delete" && selectedFileName) {
       await onDeleteFile(selectedFileName, true);
+      if (
+        deletedFileIndex != null &&
+        selectedFileIndex != null &&
+        deletedFileIndex < selectedFileIndex
+      ) {
+        setSelectedFileIndex(selectedFileIndex - 1);
+      }
+    } else if (option === "remove" && selectedFileName) {
+      onRemoveFile(selectedFileName);
       if (
         deletedFileIndex != null &&
         selectedFileIndex != null &&


### PR DESCRIPTION
Closes: #64 

Description: 

## Changes
- Added a new "Remove" option to the file context menu alongside existing "Rename" and "Delete" options
- Implemented `removeFileFromMenu` function to handle file removal
- Updated FileExplorer component to handle the new remove action

## Functionality Difference
- **Remove**: Only remove the file from the UI/file explorer menu. The file remains in 'db' storage and can be recovered by reopening/uploading the file.
- **Delete**: Completely deletes the file from both the UI and IndexedDB storage. Cannot be recovered without re-uploading.

## How to Test
1. Right-click on any file in the file explorer
2. You should see three options:
   - Rename
   - Remove
   - Delete

3. To test Remove:
   - Right-click a file and select "Remove"
   - The file should disappear from the file explorer
   - You can recover the file by refreshing the page