### PR TITLE
fixed metadata not showing on deployed page.

### DIFF
--- a/DEV_INSTRUCTIONS/DevInstructions.md
+++ b/DEV_INSTRUCTIONS/DevInstructions.md
@@ -17,6 +17,6 @@ to
   appHtml: resolveApp('public/index.html'),
 and change it back after deployment.
 
-If any changes are made to Conversion.js in the root folder, make sure those changes are reflected in the public/Conversion.js file as well.
+If any changes are made to Conversion.js or libantimony.js in the root folder, make sure those changes are reflected in the public/Conversion.js or public/libantimony.js files as well. This is because the deployed page utilizes the version in the public/ folder. 
 
 Run "npm run deploy" in terminal to deploy the changes.


### PR DESCRIPTION
* Updated `public/libantimony.js` to be in sync with root `libantimony.js` and added a comment in DevInstructions.md to mention this as well. 
* The changes are currently live https://sys-bio.github.io/AntimonyEditor/ as the changes only affect deployed and not local AWE.