### PR TITLE
Rename fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,17 +309,24 @@ const App: React.FC = () => {
             <div className="fileExplorerContainer">
               <div className="fileExplorerTitle">File Explorer</div>
             </div>
+            {db ? (
             <FileExplorer
               key={fileExplorerKey}
+              database={db}
               files={uploadedFiles}
               setFiles={setUploadedFiles}
               onFileClick={handleFileClick}
               onDeleteFile={deleteFile}
+              handleNewFile={handleNewFile}
               selectedFileIndex={selectedFileIndex}
               setSelectedFileIndex={setSelectedFileIndex}
               selectedFileName={selectedFileName}
               setSelectedFileName={setSelectedFileName}
             />
+            ) : (
+              // You can provide a loading message or handle the absence of the database as needed
+              <div>Loading...</div>
+            )}
           </section>
           <section className="editor">
             {db ? ( // Conditionally render the AntimonyEditor component when db is defined

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState, useRef } from "react";
 import "./FileExplorer.css";
 import ContextMenu from "../context-menu/ContextMenu";
+import { IDBPDatabase, DBSchema } from "idb";
+
+interface MyDB extends DBSchema {
+  files: {
+    key: string;
+    value: { name: string; content: string };
+  };
+}
 
 /**
  * @description FileExplorerProps interface
@@ -25,6 +33,7 @@ interface FileExplorerProps {
   setFiles: React.Dispatch<React.SetStateAction<{ name: string; content: string }[]>>;
   onFileClick: (fileContent: string, fileName: string, index: number) => void;
   onDeleteFile: (fileName: string, deleteFromFileExplorer: boolean) => Promise<void>;
+  handleNewFile: (newFileName: string, fileContent: string) => Promise<void>;
   selectedFileIndex: number | null;
   setSelectedFileIndex: React.Dispatch<React.SetStateAction<number | null>>;
   selectedFileName: string;
@@ -43,11 +52,13 @@ interface FileExplorerProps {
  * @param setSelectedFileName - FileExplorerProp
  * @returns - FileExplorer component
  */
-const FileExplorer: React.FC<FileExplorerProps> = ({
+const FileExplorer: React.FC<FileExplorerProps & {database: IDBPDatabase<MyDB>}> = ({
   files,
+  database,
   setFiles,
   onFileClick,
   onDeleteFile,
+  handleNewFile,
   selectedFileIndex,
   setSelectedFileIndex,
   selectedFileName,
@@ -186,7 +197,12 @@ const FileExplorer: React.FC<FileExplorerProps> = ({
         }
         return file;
       });
-
+      let oldFile = await database.transaction("files").objectStore("files").get(selectedFileName);
+      let content = "";
+      if (oldFile && oldFile.content) {
+        content = oldFile.content;
+      } 
+      await handleNewFile(newFileName, content);
       await onDeleteFile(selectedFileName, false);
       setFiles(updatedFiles);
       setSelectedFileName(newFileName);

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -22,6 +22,7 @@ interface MyDB extends DBSchema {
  * @property {string} onFileClick[].fileName - The name of the file
  * @property {string} onFileClick[].index - The index of the file
  * @property {function} onDeleteFile - The onDeleteFile function that deletes the given file
+ * @property {function} handleNewFile - The handleNewFile function that adds the given file to the database
  * @property {number | null} selectedFileIndex - The index of the currently selected file
  * @property {function} setSelectedFileIndex - The function to set the selectedFileIndex
  * @property {string} selectedFileName - The name of the currently selected file


### PR DESCRIPTION
Fixes issue #82 

Overview:
- Renaming a file results in the renamed file with no content inside.
- Refreshing the page without editing the renamed file causes the file to disappear afterwards

Changes:
- In the handleRenameComplete method, save the newly renamed file and contents in the database

Tests:
- All tests pass
- AWE builds successfully in `npm run build` 