### PR TITLE
added about option with version number

### DIFF
--- a/DEV_INSTRUCTIONS/DevInstructions.md
+++ b/DEV_INSTRUCTIONS/DevInstructions.md
@@ -19,6 +19,6 @@ and change it back after deployment.
 
 If any changes are made to Conversion.js or libantimony.js in the root folder, make sure those changes are reflected in the public/Conversion.js or public/libantimony.js files as well. This is because the deployed page utilizes the version in the public/ folder. 
 
-Additionally, make sure to update the version number before deploying. Navigate to HeaderMenu.tsx and update the versionNumber constant (line 87).
+Additionally, make sure to update the version number before deploying. Navigate to HeaderMenu.tsx and update the versionNumber constant.
 
 Run "npm run deploy" in terminal to deploy the changes.

--- a/DEV_INSTRUCTIONS/DevInstructions.md
+++ b/DEV_INSTRUCTIONS/DevInstructions.md
@@ -19,4 +19,6 @@ and change it back after deployment.
 
 If any changes are made to Conversion.js or libantimony.js in the root folder, make sure those changes are reflected in the public/Conversion.js or public/libantimony.js files as well. This is because the deployed page utilizes the version in the public/ folder. 
 
+Additionally, make sure to update the version number before deploying. Navigate to HeaderMenu.tsx and update the versionNumber constant (line 87).
+
 Run "npm run deploy" in terminal to deploy the changes.

--- a/src/components/header-menu/HeaderMenu.css
+++ b/src/components/header-menu/HeaderMenu.css
@@ -127,3 +127,26 @@ header {
   display: none;
 }
 
+.modal-background {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000; /* Ensures modal appears above other content */
+}
+
+.about-modal {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0px 0px 10px rgba(0,0,0,0.25);
+  max-width: 400px;
+  width: 80%;
+  text-align: center;
+  z-index: 1001;
+}
+

--- a/src/components/header-menu/HeaderMenu.css
+++ b/src/components/header-menu/HeaderMenu.css
@@ -140,13 +140,14 @@ header {
 }
 
 .about-modal {
-  background-color: white;
+  background-color: #333;
   padding: 2rem;
-  border-radius: 10px;
-  box-shadow: 0px 0px 10px rgba(0,0,0,0.25);
+  border-radius: 5px;
+  border: 1px solid #ccc; 
   max-width: 400px;
   width: 80%;
   text-align: center;
+  color: white;
   z-index: 1001;
 }
 

--- a/src/components/header-menu/HeaderMenu.tsx
+++ b/src/components/header-menu/HeaderMenu.tsx
@@ -81,8 +81,10 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
   const [convertedFileContent, setConvertedFileContent] = useState<string>("");
   const [isConverted, setIsConverted] = useState<boolean>(false);
   const [isModalVisible, setModalVisible] = useState<boolean>(false);
+  const [isAboutModalVisible, setAboutModalVisible] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const versionNumber = "1.0.0";
 
   /**
    * @description Handle clicking outside the dropdown to close it.
@@ -445,6 +447,14 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
                       Report Issue
                     </a>
                   </li>
+                  <li onClick={() => { 
+                    setDropdownVisible("");
+                    setAboutModalVisible(true);
+                    }}>
+                    <div className="header-menu-command">
+                      About
+                    </div>
+                  </li>
                 </ul>
               )}
             </li>
@@ -462,6 +472,20 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
           setUploadedFiles={setUploadedFiles}
           isConverted={isConverted}
         />
+      )}
+      {isAboutModalVisible && (
+        <div 
+        className="modal-background" 
+        onClick={() => setAboutModalVisible(false)}
+      >
+        <div 
+          className="about-modal" 
+          onClick={(e) => e.stopPropagation()}
+        >
+          <h1>Antimony Web Editor</h1>
+          <h2>Version {versionNumber}</h2>
+        </div>
+      </div>
       )}
     </>
   );


### PR DESCRIPTION
Overview: 
Added about option in header menu. Under help, there is a new option "about" that leads to a popup with the version number of AWE. To close the popup, click anywhere in the background.

Changes: 
Added an about option in HeaderMenu.tsx that displays the about modal when clicked. 
Added CSS styles for the modal background and about modal in HeaderMenu.css
Added instructions in DevInstructions.md on how to update the version number before deploying

Test: passed all tests from npm run test

How to use feature manually: click on "Help" and then "About"
