### PR TITLE
Improve file explorer styling

### DIFF
--- a/src/components/file-explorer/FileExplorer.css
+++ b/src/components/file-explorer/FileExplorer.css
@@ -3,7 +3,7 @@
   overflow: auto;
 }
 
-.file-explorer ul {
+.file-explorer-list {
   list-style: none;
   display: flex;
   align-items: flex-start;
@@ -11,6 +11,10 @@
   flex-direction: column;
   font-size: 0;
   padding: 0px 10px;
+}
+
+.file-explorer-list > li {
+  width: 100%;
 }
 
 .file-btn:hover,
@@ -26,15 +30,16 @@
   font-weight: normal !important;
   line-height: 1.2;
   margin-left: 3px;
-  padding: 2px 7px;
+  overflow: hidden;
+  padding: 5px;
   position: relative;
-  text-align: center;
+  text-align: left;
   text-decoration: none !important;
   text-overflow: ellipsis;
   text-shadow: none;
+  width: 100%;
   white-space: nowrap;
   color: white;
-  padding: 5px;
   font-size: 16px;
   border: none;
   cursor: pointer;

--- a/src/components/file-explorer/FileExplorer.css
+++ b/src/components/file-explorer/FileExplorer.css
@@ -46,6 +46,15 @@
 }
 
 .rename-input {
+  background-color: #1c1c1c;
+  border: 1.5px solid #ddd;
+  border-radius: 2px;
+  box-sizing: border-box;
+  color: white;
   font-size: 16px;
-  margin: 2px 0;
+  line-height: 1.2;
+  margin-left: 3px;
+  outline: none;
+  padding: 5px;
+  width: 100%;
 }

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -226,7 +226,7 @@ const FileExplorer: React.FC<FileExplorerProps & {database: IDBPDatabase<MyDB>}>
 
   return (
     <div className="file-explorer">
-      <ul>
+      <ul className="file-explorer-list">
         {files.map((file, index) => (
           <li key={index}>
             {isRenaming && renamingFileIndex === index ? (


### PR DESCRIPTION
Changes:
 - long file names truncated
 - rename input box styling matches the rest of the application
 - file buttons extend the entire width of the explorer

Testing:
 - manual testing
 - `npm run test` all passing
 - `npm run build` successful

<img width="276" alt="Screenshot 2025-04-18 at 2 23 25 PM" src="https://github.com/user-attachments/assets/486795d2-0b5b-4cbe-aa07-423a30a492aa" />
