### PR TITLE
Annotation Recommendation UI updates and preference saving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,7 @@ const App: React.FC = () => {
    * @description Use the openDB function to open the database
    */
   useEffect(() => {
-    openDB<MyDB>("antimony_editor_db", 1, {
+    openDB<MyDB>("antimony_editor_db", undefined, {
       upgrade(db) {
         if (!db.objectStoreNames.contains("files")) {
           db.createObjectStore("files", { keyPath: "name" });
@@ -106,6 +106,22 @@ const App: React.FC = () => {
         }
       },
     }).then((database) => {
+
+      let newVersion = database.version + 1
+
+      if (!database.objectStoreNames.contains("settings")) {
+        openDB<MyDB>("antimony_editor_db", newVersion, {
+          upgrade(db) {
+            if (!db.objectStoreNames.contains("files")) {
+              db.createObjectStore("files", { keyPath: "name" });
+            }
+            if (!db.objectStoreNames.contains("settings")) {
+              db.createObjectStore("settings", {keyPath: "name"});
+            }
+          }
+        })
+      }
+
       setDb(database); // Store the database instance in the state
       database.getAll("files").then((files) => {
         setUploadedFiles(files);
@@ -117,7 +133,6 @@ const App: React.FC = () => {
           setPreferences(JSON.parse(settings.content));
         } else {
           setPreferences(defaultPreferences);
-          console.log(defaultPreferences);
           database.put("settings", {name: "settings.json", content:JSON.stringify(defaultPreferences)});
         }
       })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,35 +127,6 @@ const App: React.FC = () => {
         })
       })
     })
-
-
-    // openDB<MyDB>("antimony_editor_db").then((db) => {
-    //   openDB<MyDB>("antimony_editor_db", db.version+1, {
-    //     upgrade(db) {
-    //       if (!db.objectStoreNames.contains("files")) {
-    //         db.createObjectStore("files", { keyPath: "name" });
-    //       }
-    //       if (!db.objectStoreNames.contains("settings")) {
-    //         db.createObjectStore("settings", {keyPath: "name"});
-    //       }
-    //     }
-    //   }).then((database) => {
-    //     setDb(database); // Store the database instance in the state
-    //     database.getAll("files").then((files) => {
-    //       setUploadedFiles(files);
-    //     });
-    //     // Get the settings file if it currently exists, else create settings file with
-    //     // defaultPreferences loaded in
-    //     database.get("settings", "settings.json").then((settings) => {
-    //       if (settings) {
-    //         setPreferences(JSON.parse(settings.content));
-    //       } else {
-    //         setPreferences(defaultPreferences);
-    //         database.put("settings", {name: "settings.json", content:JSON.stringify(defaultPreferences)});
-    //       }
-    //     })
-    //   })
-    // })
   }, []);
 
   /**

--- a/src/components/antimony-editor/AntimonyEditor.tsx
+++ b/src/components/antimony-editor/AntimonyEditor.tsx
@@ -10,6 +10,7 @@ import ModelSemanticsChecker from "../../language-handler/ModelSemanticChecker";
 import { IDBPDatabase, DBSchema } from "idb";
 import { SrcPosition, SrcRange } from "../../language-handler/Types";
 import TurndownService from "turndown";
+import { MyDB } from "../../App";
 
 /**
  * @description AntimonyEditorProps interface
@@ -33,23 +34,6 @@ interface AntimonyEditorProps {
   setHighlightColor: (color: string) => void;
   highlightColor: string;
   handleNewFile: (newFileName: string, newFileContent: string) => Promise<void>;
-}
-
-/**
- * @description IndexedDB schema
- * @interface
- * @property {object} files - The files object
- * @property {string} files.key - The key of the files object
- * @property {object} files.value - The value of the files object
- * @property {string} files.value.name - The name of the file
- * @property {string} files.value.content - The content of the file
- * @extends DBSchema
- */
-interface MyDB extends DBSchema {
-  files: {
-    key: string;
-    value: { name: string; content: string };
-  };
 }
 
 /**

--- a/src/components/file-explorer/FileExplorer.tsx
+++ b/src/components/file-explorer/FileExplorer.tsx
@@ -2,13 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import "./FileExplorer.css";
 import ContextMenu from "../context-menu/ContextMenu";
 import { IDBPDatabase, DBSchema } from "idb";
-
-interface MyDB extends DBSchema {
-  files: {
-    key: string;
-    value: { name: string; content: string };
-  };
-}
+import { MyDB } from "../../App";
 
 /**
  * @description FileExplorerProps interface

--- a/src/components/header-menu/HeaderMenu.tsx
+++ b/src/components/header-menu/HeaderMenu.tsx
@@ -90,12 +90,10 @@ interface HeaderMenuProps {
 const HeaderMenu: React.FC<HeaderMenuProps> = ({
   db,
   setDb,
-
   fileName,
   fileContent,
   setFileContent,
   setUploadedFiles,
-
   handleConversionAntimony,
   handleConversionSBML,
   handleFileDownload,
@@ -103,7 +101,6 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
   handleNewFile,
   preferences,
   handlePreferenceUpdate,
-
   highlightColor,
   setHighlightColor,
   colors,
@@ -111,11 +108,9 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
   const [isModalVisible, setModalVisible] = useState(false);
   const [convertedFileContent, setConvertedFileContent] = useState("");
   const [isConverted, setIsConverted] = useState(false);
-
   const [visibleDropdown, setVisibleDropdown] = useState("");
   const headerRef = useRef<HTMLElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
   const [isAboutModalVisible, setAboutModalVisible] = useState(false);
   const [aboutContent, setAboutContent] = useState('');
 
@@ -256,7 +251,7 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
     ],
 
     Annotate: [
-      { name: "Recommend Annotations for All", onSelected: wrapOnSelected(handleAnnotateClick) },
+      { name: "Recommend Annotations", onSelected: wrapOnSelected(handleAnnotateClick) },
     ],
 
     Settings: [

--- a/src/components/header-menu/HeaderMenu.tsx
+++ b/src/components/header-menu/HeaderMenu.tsx
@@ -7,8 +7,24 @@ import RecommendAnnotationModal from "../recommend-annotation/RecommendAnnotatio
 
 import { IDBPDatabase } from "idb";
 
-export interface HeaderMenuProps {
-  /** The database with all the files and stuff */
+/**
+ * @description HeaderMenuProps interface
+ * @interface
+ * @property {IDBPDatabase<MyDB> | null | undefined} db - The database
+ * @property {function} setDb - Set the database
+ * @property {string} fileName - The name of the current selected file
+ * @property {string} fileContent - The contents of the current selected file
+ * @property {function} setFileContent - Sets the file content
+ * @property {function} setUploadedFiles - Sets the uploaded files
+ * @property {function} handleConversionAntimony - Handle the Antimony to SBML file conversion process
+ * @property {function} handleConversionSBML - Handle the SBML to Antimony file conversion
+ * @property {function} handleFileDownload - Handle the file download
+ * @property {function} handleFileUpload - Handle the file upload
+ * @property {function} handleNewFile - Handle a new file
+ * @property {dict} preferences - A stateful object that contains the user's AWE preferences
+ * @property {function} handlePreferenceUpdate - A function used to update and save the user's AWE preferences
+ */
+interface HeaderMenuProps {
   db: IDBPDatabase<MyDB> | null | undefined;
   setDb: (database: IDBPDatabase<MyDB> | null) => void;
 
@@ -33,6 +49,8 @@ export interface HeaderMenuProps {
   ) => Promise<void>;
   /**  Handle a new file */
   handleNewFile: (newFileName: string, fileContent: string) => Promise<void>;
+  preferences: {[key: string]: any};
+  handlePreferenceUpdate: (preferences: {[key: string]: any}) => void;
 
   /** Current highlight color */
   highlightColor: string,
@@ -42,6 +60,29 @@ export interface HeaderMenuProps {
   colors: { name: string; color: string }[];
 }
 
+/**
+ * @description HeaderMenu component
+ * @param db - HeaderMenuProp
+ * @param setDb - HeaderMenuProp
+ * @param fileName - HeaderMenuProp
+ * @param fileContent - HeaderMenuProp
+ * @param setFileContent - HeaderMenuProp
+ * @param setUploadedFiles - setUploadedFiles
+ * @param handleConversionAntimony - HeaderMenuProp
+ * @param handleConversionSBML - HeaderMenuProp
+ * @param handleFileDownload - HeaderMenuProp
+ * @param handleFileUpload - HeaderMenuProp
+ * @param handleNewFile - HeaderMenuProp
+ * @param preferences - A stateful object that contains the user's AWE preferences
+ * @param handlePreferenceUpdate - A function used to update and save the user's AWE preferences
+ * @example - <HeaderMenu
+ *              handleConversionAntimony={handleConversionAntimony}
+ *              handleConversionSBML={handleConversionSBML}
+ *              handleFileDownload={handleFileDownload}
+ *              handleFileUpload={handleFileUpload}
+ *            />
+ * @returns - HeaderMenu component
+ */
 const HeaderMenu: React.FC<HeaderMenuProps> = ({
   db,
   setDb,
@@ -56,6 +97,8 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
   handleFileDownload,
   handleFileUpload,
   handleNewFile,
+  preferences,
+  handlePreferenceUpdate,
 
   highlightColor,
   setHighlightColor,
@@ -282,6 +325,8 @@ const HeaderMenu: React.FC<HeaderMenuProps> = ({
           setFileContent={setFileContent}
           setUploadedFiles={setUploadedFiles}
           isConverted={isConverted}
+          preferences={preferences}
+          handlePreferenceUpdate={handlePreferenceUpdate}
         />
       )}
       

--- a/src/components/recommend-annotation/RecommendAnnotationModal.css
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.css
@@ -107,34 +107,23 @@
   color: #ff6666;
 }
 
-.algo-list-container {
-  padding:10px;
-  display: grid;
-  vertical-align: middle;
-}
-
-.algo-info-box {
-  margin: 10px;
-  height: 150px;
-  max-height: 150px;
-  border: 0px solid #5b5b5c;
-  padding: 10px;
-  border-radius: 8px;
-  background-color: rgba(0,0,0,0.5);
-  color:#ffffff;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  vertical-align: middle;
+.select-annotator-container {
+  display:flex;
+  justify-content: center;
   align-items: center;
+  gap:10px;
 }
 
-.algo-info-box:hover {
-  background-color: rgba(0, 0, 0, 0.3);
-}
-
-.algo-info-header {
-  margin-top: 0;
-  margin-bottom: 0;
+.select-annotator {
+  margin:0;
+  padding: 0;
+  min-width: 150px;
+  background-color: #5b5b5c;
   color: #ffffff;
-  font-size: 1.5em;
-  font-weight: bold;
+  border-radius: 3px;
+}
+
+.select-options {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
 }

--- a/src/components/recommend-annotation/RecommendAnnotationModal.css
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.css
@@ -93,7 +93,6 @@
   width: 100%;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
-  box-shadow: #333;
   padding:10px;
   background-color: #5b5b5c;
 }

--- a/src/components/recommend-annotation/RecommendAnnotationModal.css
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.css
@@ -1,4 +1,85 @@
+.slider-number {
+  width: 30px;
+}
+
+.slider-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.save-prompt-container {
+  z-index: 1003;
+  position: absolute;
+  background-color: #1e1e1e;
+  top:20%;
+  left:50%;
+  transform: translateX(-50%);
+  width: 500px;
+  height: 150px;
+  padding:0px;
+  border: 0px;
+  border-radius: 10px;
+  color:#ffffff;
+  display:flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.save-prompt {
+  justify-self: center;
+  height: 100%;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 60px;
+}
+
+.save-prompt-buttons {
+  align-self: flex-end;
+  justify-self: center;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  border: 0px;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.save-prompt-button {
+  user-select: none;
+  text-align: center;
+  width: 80px;
+  border: 1px solid #ccc;
+  background-color: #333;
+  padding: 10px;
+}
+
+.save-prompt-button:hover {
+  background-color: #5b5b5c;
+}
+
+.save-prompt-background {
+  z-index: 1002;
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .annot-modal {
+  z-index: 1000;
   position: absolute;
   top:20%;
   left:50%;
@@ -9,6 +90,7 @@
 }
 
 .modal-title-container {
+  width: 100%;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   box-shadow: #333;
@@ -57,6 +139,19 @@
   background-color: #333;
   border: 1px solid #ccc;
   border-radius: 5px;
+}
+
+.annot-recommend-button-grey {
+  user-select: none;
+  text-align: center;
+  padding: 5px;
+  background-color: #333333;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.annot-recommend-button:hover {
+  background-color: #5b5b5c;
 }
 
 .annot-grid {
@@ -115,6 +210,7 @@
 }
 
 .select-annotator {
+  cursor: pointer;
   margin:0;
   padding: 0;
   min-width: 150px;

--- a/src/components/recommend-annotation/RecommendAnnotationModal.css
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.css
@@ -1,5 +1,26 @@
 .annot-modal {
-  width: 900px;
+  position: absolute;
+  top:20%;
+  left:50%;
+  padding:0px;
+  width: 700px;
+  border: 0px;
+  border-radius: 10px;
+}
+
+.modal-title-container {
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  box-shadow: #333;
+  padding:10px;
+  background-color: #5b5b5c;
+}
+
+.modal-title {
+  text-align: left;
+  color:#ffffff;
+  font-size: 18px;
+  font-weight: bold;
 }
 
 .annot-arguments-container {
@@ -84,4 +105,36 @@
 
 .low-match {
   color: #ff6666;
+}
+
+.algo-list-container {
+  padding:10px;
+  display: grid;
+  vertical-align: middle;
+}
+
+.algo-info-box {
+  margin: 10px;
+  height: 150px;
+  max-height: 150px;
+  border: 0px solid #5b5b5c;
+  padding: 10px;
+  border-radius: 8px;
+  background-color: rgba(0,0,0,0.5);
+  color:#ffffff;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  vertical-align: middle;
+  align-items: center;
+}
+
+.algo-info-box:hover {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.algo-info-header {
+  margin-top: 0;
+  margin-bottom: 0;
+  color: #ffffff;
+  font-size: 1.5em;
+  font-weight: bold;
 }

--- a/src/components/recommend-annotation/RecommendAnnotationModal.tsx
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.tsx
@@ -133,8 +133,6 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   const [step, setStep] = useState<number>(1);
   const [progress, setProgress] = useState<number>(0);
   const [progressMessage, setProgressMessage] = useState<string>("Loading...");
-  // const [cutoff, setCutoff] = useState<number>(0.01);
-  // const [mssc, setMSSC] = useState<MSSC>(MSSC.TOP);
   const [recommender, setRecommender] = useState<any>(null);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [selectedRecommendations, setSelectedRecommendations] = useState<
@@ -449,10 +447,10 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     setSavePromptVisible(false);
     setUnsavedPreferences(JSON.parse(JSON.stringify(preferences[PreferenceTypes.ANNOTATOR])));
     if (afterSaveAction) {
-      let a = afterSaveAction.current;
+      let action = afterSaveAction.current;
       afterSaveAction.current = () => {};
-      if (a)
-        a();
+      if (action)
+        action();
     }
   }
 
@@ -480,7 +478,7 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
             </div> 
             <div className="save-prompt-button"
             onClick={() => handleCancelSavePreferences()}>
-              Cancel
+              No
             </div>
           </div>   
         </div>
@@ -528,9 +526,25 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
               
               {annotatorIDtoForm[selectedAnnotator]}
             </div>
-            {selectedAnnotator === Annotators.AMAS ? <div
+            {selectedAnnotator === Annotators.AMAS ? <div 
+              tabIndex={0}
               className= "annot-recommend-button"
-              onClick={handleGenerateAnnotations}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  if (isUnsaved) {
+                    setSavePromptVisible(true)
+                  } else {
+                    handleGenerateAnnotations()
+                  }
+                }
+              }}
+              onClick={() => {
+                if (isUnsaved) {
+                  setSavePromptVisible(true)
+                } else {
+                  handleGenerateAnnotations()
+                }
+              }}
             >
               Generate annotation recommendations
             </div>:

--- a/src/components/recommend-annotation/RecommendAnnotationModal.tsx
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.tsx
@@ -21,6 +21,47 @@ enum MSSC {
   TOP = "top",
   ABOVE = "above",
 }
+interface AlgorithmInfo {
+  name: string;
+  description: string;
+  version: string;
+  sourceCode: string;
+}
+
+const algorithms: AlgorithmInfo[] = [
+  { name: "AMAS", description: "Placeholder", version: "1.0", sourceCode: "https://github.com/sys-bio/AMAS" },
+  { name: "Example", description: "An example alternative algorithm", version: "1.2.3.4 beta", sourceCode: "https://sys-bio.github.io/AntimonyEditor/" }
+];
+
+class AnnotationAlgorithm {
+
+  info:AlgorithmInfo;
+
+  constructor(info:AlgorithmInfo) {
+    this.info = info;
+  }
+
+  getForm = () => {
+    return (
+      <>
+      </>
+    )
+  }
+
+  getResults = () => {
+    return (
+      <>
+      </>
+    )
+  }
+
+  getInfo = () => {
+    return (
+      <>
+      </>
+    )
+  }
+}
 
 interface Recommendation {
   type: string;
@@ -100,7 +141,7 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   setUploadedFiles,
   isConverted,
 }) => {
-  const [step, setStep] = useState<number>(1);
+  const [step, setStep] = useState<number>(0);
   const [progress, setProgress] = useState<number>(0);
   const [progressMessage, setProgressMessage] = useState<string>("Loading...");
   const [cutoff, setCutoff] = useState<number>(0.01);
@@ -314,21 +355,20 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   const sortedRecommendations =
     sortConfig.field !== null
       ? [...recommendations].sort((a, b) => {
-          const field = sortConfig.field as keyof typeof a;
-          const valueA = a[field];
-          const valueB = b[field];
-
-          if (typeof valueA === "number" && typeof valueB === "number") {
-            return sortConfig.order === SortOrder.ASC
-              ? valueA - valueB
-              : valueB - valueA;
-          } else if (typeof valueA === "string" && typeof valueB === "string") {
-            return sortConfig.order === SortOrder.ASC
-              ? valueA.localeCompare(valueB)
-              : valueB.localeCompare(valueA);
-          }
-          return 0;
-        })
+        const field = sortConfig.field as keyof typeof a;
+        const valueA = a[field];
+        const valueB = b[field];
+        if (typeof valueA === "number" && typeof valueB === "number") {
+          return sortConfig.order === SortOrder.ASC
+            ? valueA - valueB
+            : valueB - valueA;
+        } else if (typeof valueA === "string" && typeof valueB === "string") {
+          return sortConfig.order === SortOrder.ASC
+            ? valueA.localeCompare(valueB)
+            : valueB.localeCompare(valueA);
+        }
+        return 0;
+      })
       : recommendations;
 
   /**
@@ -396,16 +436,33 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
       >
         <div className="modal-title-container">
           <div className="modal-title">
-            {step === 1 && `Select arguments:`}
+            {step === 0 && 'Select Algorithm'}
+            {step === 1 && `Select Arguments`}
             {step === 2 && (
               <div>
                 <div>{progressMessage}</div>
                 <progress value={progress} />
               </div>
             )}
-            {step === 3 && `Select annotations to update:`}
+            {step === 3 && `Select annotations to update`}
           </div>
         </div>
+
+
+        {step === 0 && (
+          <div className="algo-list-container">{algorithms.map((a) => (
+            <div className="algo-info-box" onClick={() => {setStep(1)}}>
+              <h2 className="algo-info-header">{a.name}</h2>
+              <div className="algo-info-description">
+                <div><a href={a.sourceCode}>Source</a></div>
+                <div>{"Version: " + a.version}</div>
+                {}
+                <div>{a.description}</div>
+              </div>
+            </div>
+          ))}
+          </div>
+        )}
 
         {step === 1 && (
           <>
@@ -485,9 +542,8 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
                 const key = getRecommendationKey(rec);
                 return (
                   <div
-                    className={`annot-grid-row ${
-                      rec.isLowMatch && "low-match"
-                    }`}
+                    className={`annot-grid-row ${rec.isLowMatch && "low-match"
+                      }`}
                     key={key}
                   >
                     <div className="annot-grid-item">{rec.type}</div>

--- a/src/components/recommend-annotation/RecommendAnnotationModal.tsx
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.tsx
@@ -21,47 +21,18 @@ enum MSSC {
   TOP = "top",
   ABOVE = "above",
 }
-interface AlgorithmInfo {
+interface AnnotatorInfo {
+  id: string;
   name: string;
   description: string;
   version: string;
   sourceCode: string;
 }
 
-const algorithms: AlgorithmInfo[] = [
-  { name: "AMAS", description: "Placeholder", version: "1.0", sourceCode: "https://github.com/sys-bio/AMAS" },
-  { name: "Example", description: "An example alternative algorithm", version: "1.2.3.4 beta", sourceCode: "https://sys-bio.github.io/AntimonyEditor/" }
+const annotators: AnnotatorInfo[] = [
+  { id: "amas", name: "AMAS", description: "Placeholder", version: "1.0", sourceCode: "https://github.com/sys-bio/AMAS" },
+  { id: "example", name: "Example", description: "An example alternative algorithm", version: "1.2.3.4 beta", sourceCode: "https://sys-bio.github.io/AntimonyEditor/" }
 ];
-
-class AnnotationAlgorithm {
-
-  info:AlgorithmInfo;
-
-  constructor(info:AlgorithmInfo) {
-    this.info = info;
-  }
-
-  getForm = () => {
-    return (
-      <>
-      </>
-    )
-  }
-
-  getResults = () => {
-    return (
-      <>
-      </>
-    )
-  }
-
-  getInfo = () => {
-    return (
-      <>
-      </>
-    )
-  }
-}
 
 interface Recommendation {
   type: string;
@@ -141,7 +112,7 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   setUploadedFiles,
   isConverted,
 }) => {
-  const [step, setStep] = useState<number>(0);
+  const [step, setStep] = useState<number>(1);
   const [progress, setProgress] = useState<number>(0);
   const [progressMessage, setProgressMessage] = useState<string>("Loading...");
   const [cutoff, setCutoff] = useState<number>(0.01);
@@ -156,6 +127,7 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     order: SortOrder.ASC,
   });
   const modalRef = useRef<HTMLDivElement>(null);
+  const [selectedAnnotator, setSelectedAnnotator] = useState<string>("amas");
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -426,6 +398,36 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     }
   };
 
+  const annotatorIDtoForm: {[key:string]: any}= {
+    "amas": <>
+      <div className="annot-argument-container">
+        <label htmlFor="cutoffInput">Cutoff Score (0.0 - 1.0):</label>
+        <input
+          id="cutoffInput"
+          type="number"
+          value={cutoff}
+          onChange={handleCutoff}
+          min="0.0"
+          max="1.0"
+          step="0.01"
+        />
+      </div>
+      <div className="annot-argument-container">
+        <label htmlFor="msscInput">
+          Match Score Selection Criteria (MSSC):
+        </label>
+        <select id="msscInput" value={mssc} onChange={handleMSSC}>
+          {Object.values(MSSC).map((value) => (
+            <option key={value} value={value}>
+              {value.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>,
+    "example": <>Example Preference</>
+  }
+
   return (
     <>
       <div className="shadow-background" />
@@ -436,7 +438,6 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
       >
         <div className="modal-title-container">
           <div className="modal-title">
-            {step === 0 && 'Select Algorithm'}
             {step === 1 && `Select Arguments`}
             {step === 2 && (
               <div>
@@ -448,49 +449,24 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
           </div>
         </div>
 
-
-        {step === 0 && (
-          <div className="algo-list-container">{algorithms.map((a) => (
-            <div className="algo-info-box" onClick={() => {setStep(1)}}>
-              <h2 className="algo-info-header">{a.name}</h2>
-              <div className="algo-info-description">
-                <div><a href={a.sourceCode}>Source</a></div>
-                <div>{"Version: " + a.version}</div>
-                {}
-                <div>{a.description}</div>
-              </div>
-            </div>
-          ))}
-          </div>
-        )}
-
         {step === 1 && (
           <>
             <div className="annot-arguments-container">
-              <div className="annot-argument-container">
-                <label htmlFor="cutoffInput">Cutoff Score (0.0 - 1.0):</label>
-                <input
-                  id="cutoffInput"
-                  type="number"
-                  value={cutoff}
-                  onChange={handleCutoff}
-                  min="0.0"
-                  max="1.0"
-                  step="0.01"
-                />
-              </div>
-              <div className="annot-argument-container">
-                <label htmlFor="msscInput">
-                  Match Score Selection Criteria (MSSC):
-                </label>
-                <select id="msscInput" value={mssc} onChange={handleMSSC}>
-                  {Object.values(MSSC).map((value) => (
-                    <option key={value} value={value}>
-                      {value.toUpperCase()}
-                    </option>
-                  ))}
+              <div className="select-annotator-container">
+                <>Selected Annotator:</>
+                <select
+                  className="select-annotator"
+                  value={selectedAnnotator}
+                  onChange={e => setSelectedAnnotator(e.target.value)}
+                >
+                  {annotators.map((a) => (
+                    <option className="select-options" value={a.id}>{a.name}</option>
+                  ))
+                  }
                 </select>
               </div>
+              
+              {annotatorIDtoForm[selectedAnnotator]}
             </div>
             <div
               className="annot-recommend-button"

--- a/src/components/recommend-annotation/RecommendAnnotationModal.tsx
+++ b/src/components/recommend-annotation/RecommendAnnotationModal.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../libs/AMAS-js/src/recommend_annotation";
 
 import { openDB, IDBPDatabase } from "idb";
+import { PreferenceTypes } from "../../App";
 
 /**
  * Represents the Match Score Selection Criteria (MSSC) used in AMAS.
@@ -21,6 +22,8 @@ enum MSSC {
   TOP = "top",
   ABOVE = "above",
 }
+
+// Annotator Info Interface
 interface AnnotatorInfo {
   id: string;
   name: string;
@@ -29,6 +32,7 @@ interface AnnotatorInfo {
   sourceCode: string;
 }
 
+// Annotator Info Dictionary
 const annotators: AnnotatorInfo[] = [
   { id: "amas", name: "AMAS", description: "Placeholder", version: "1.0", sourceCode: "https://github.com/sys-bio/AMAS" },
   { id: "example", name: "Example", description: "An example alternative algorithm", version: "1.2.3.4 beta", sourceCode: "https://sys-bio.github.io/AntimonyEditor/" }
@@ -45,6 +49,12 @@ interface Recommendation {
   existing: number;
   updateAnnotation: string;
   isLowMatch: boolean;
+}
+
+// Available Annotators
+enum Annotators {
+  AMAS = "amas",
+  EXAMPLE = "example"
 }
 
 enum SortOrder {
@@ -68,6 +78,8 @@ interface SortConfig {
  * @property {function} setFileContent - Sets the file content
  * @property {function} setUploadedFiles - Sets the uploaded files
  * @property {boolean} isConverted - True if the fileContent was previously Antimony (.ant) and converted to SBML (.xml).
+ * @property {dict} preferences - A stateful object that contains the user's AWE preferences
+ * @property {function} handlePreferenceUpdate - A function used to update and save the user's AWE preferences
  */
 interface RecommendAnnotationModalProps {
   db: IDBPDatabase<MyDB> | null | undefined;
@@ -78,6 +90,8 @@ interface RecommendAnnotationModalProps {
   setFileContent: (fileContent: string) => void;
   setUploadedFiles: (files: { name: string; content: string }[]) => void;
   isConverted: boolean;
+  preferences: {[key:string]: any};
+  handlePreferenceUpdate: (preferences: {[key: string]: any}) => void;
 }
 
 /**
@@ -90,6 +104,8 @@ interface RecommendAnnotationModalProps {
  * @param setFileContent - RecommendAnnotationModalProp
  * @param setUploadedFiles - RecommendAnnotationModalProp
  * @param isConverted - RecommendAnnotationModalProp
+ * @param preferences - A stateful object that contains the user's AWE preferences
+ * @param handlePreferenceUpdate - A function used to update and save the user's AWE preferences
  * @example - <RecommendAnnotationModal
  *              db={db}
  *              setDb={setDb}
@@ -111,12 +127,14 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   setFileContent,
   setUploadedFiles,
   isConverted,
+  preferences,
+  handlePreferenceUpdate
 }) => {
   const [step, setStep] = useState<number>(1);
   const [progress, setProgress] = useState<number>(0);
   const [progressMessage, setProgressMessage] = useState<string>("Loading...");
-  const [cutoff, setCutoff] = useState<number>(0.01);
-  const [mssc, setMSSC] = useState<MSSC>(MSSC.TOP);
+  // const [cutoff, setCutoff] = useState<number>(0.01);
+  // const [mssc, setMSSC] = useState<MSSC>(MSSC.TOP);
   const [recommender, setRecommender] = useState<any>(null);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [selectedRecommendations, setSelectedRecommendations] = useState<
@@ -128,14 +146,32 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
   });
   const modalRef = useRef<HTMLDivElement>(null);
   const [selectedAnnotator, setSelectedAnnotator] = useState<string>("amas");
+  const [unsavedPreferences, setUnsavedPreferences] = useState<{[key:string]: any}>(JSON.parse(JSON.stringify(preferences[PreferenceTypes.ANNOTATOR])));
+  const [isUnsaved, setIsUnsaved] = useState<boolean>(false);
+  const [savePromptVisible, setSavePromptVisible] = useState<boolean>(false);
+
+  // Method to call after saving or cancelling the save prompt
+  const afterSaveAction = useRef<() => void>();
+
+  // Initialize states, mostly for debugging
+  useEffect(() => {
+    setIsUnsaved(false)
+    afterSaveAction.current = () => {};
+  }, [])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         modalRef.current &&
-        !modalRef.current.contains(event.target as Node)
+        !modalRef.current.contains(event.target as Node) &&
+        !savePromptVisible
       ) {
-        onClose(); // Close the modal if the click is outside the modal
+        if (isUnsaved) {
+          setSavePromptVisible(true);
+          afterSaveAction.current = onClose;
+        } else {
+          onClose(); // Close the modal if the click is outside the modal
+        }
       }
     };
 
@@ -143,29 +179,7 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [onClose]);
-
-  /**
-   * Handles changes to the cutoff value input field.
-   * Ensures the value stays within the valid range of 0.0 to 1.0.
-   *
-   * @param event - The change event from the number input field.
-   */
-  const handleCutoff = (event: React.ChangeEvent<HTMLInputElement>) => {
-    let value = parseFloat(event.target.value);
-    if (value >= 0.0 && value <= 1.0) {
-      setCutoff(value);
-    }
-  };
-
-  /**
-   * Handles changes to the MSSC dropdown selection.
-   *
-   * @param event - The change event from the dropdown select element.
-   */
-  const handleMSSC = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setMSSC(event.target.value as MSSC);
-  };
+  }, [onClose, isUnsaved, savePromptVisible]);
 
   /**
    * Handles the generation of annotation recommendations.
@@ -196,8 +210,8 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
       // Predict species
       const predSpec = await predictSpecies({
         recom,
-        mssc,
-        cutoff,
+        cutoff: unsavedPreferences[Annotators.AMAS]["cutoff"],
+        mssc: unsavedPreferences[Annotators.AMAS]["mssc"]
       });
 
       setProgressMessage(`Predicting ${numReactions} reactions...`);
@@ -209,8 +223,8 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
       // Predict reactions
       const predReac = await predictReactions({
         recom,
-        mssc,
-        cutoff,
+        cutoff: unsavedPreferences[Annotators.AMAS]["cutoff"],
+        mssc: unsavedPreferences[Annotators.AMAS]["mssc"]
       });
 
       setProgressMessage("Creating recommendations table...");
@@ -398,39 +412,80 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     }
   };
 
+  /**
+   * 
+   * Function to call to update the "unsaved preferences".
+   * Also updates the unsaved state to cause the save prompt to show up
+   * if any settings are different
+   * 
+   * @param annotator - Annotator's preference to update
+   * @param key - name of the preference
+   * @param value - value of the preference
+   */
+  const updateUnsavedPreferences = (annotator: Annotators, key:string, value:any) => {
+    //console.log("updating " + key + " to " + value)
+    let temp = unsavedPreferences;
+    temp[annotator][key] = value;
+    setIsUnsaved(JSON.stringify(preferences[PreferenceTypes.ANNOTATOR]) !== JSON.stringify(temp));
+    setUnsavedPreferences(temp);
+  }
+
+  const handleSavePreferences = () => {
+    let temp = JSON.parse(JSON.stringify(preferences));
+    temp[PreferenceTypes.ANNOTATOR] = unsavedPreferences
+    handlePreferenceUpdate(JSON.parse(JSON.stringify(temp)));
+    setIsUnsaved(false);
+    setSavePromptVisible(false);
+    if (afterSaveAction) {
+      let a = afterSaveAction.current;
+      afterSaveAction.current = () => {};
+      if (a)
+        a();
+    }
+  }
+
+  const handleCancelSavePreferences = () => {
+    setIsUnsaved(false);
+    setSavePromptVisible(false);
+    setUnsavedPreferences(JSON.parse(JSON.stringify(preferences[PreferenceTypes.ANNOTATOR])));
+    if (afterSaveAction) {
+      let a = afterSaveAction.current;
+      afterSaveAction.current = () => {};
+      if (a)
+        a();
+    }
+  }
+
   const annotatorIDtoForm: {[key:string]: any}= {
-    "amas": <>
-      <div className="annot-argument-container">
-        <label htmlFor="cutoffInput">Cutoff Score (0.0 - 1.0):</label>
-        <input
-          id="cutoffInput"
-          type="number"
-          value={cutoff}
-          onChange={handleCutoff}
-          min="0.0"
-          max="1.0"
-          step="0.01"
-        />
-      </div>
-      <div className="annot-argument-container">
-        <label htmlFor="msscInput">
-          Match Score Selection Criteria (MSSC):
-        </label>
-        <select id="msscInput" value={mssc} onChange={handleMSSC}>
-          {Object.values(MSSC).map((value) => (
-            <option key={value} value={value}>
-              {value.toUpperCase()}
-            </option>
-          ))}
-        </select>
-      </div>
-    </>,
-    "example": <>Example Preference</>
+    "amas": AMASForm(unsavedPreferences, updateUnsavedPreferences),
+    "example": ExampleForm(unsavedPreferences, updateUnsavedPreferences)
   }
 
   return (
     <>
       <div className="shadow-background" />
+      {savePromptVisible && 
+      <div className="save-prompt-background">
+        <div className="save-prompt-container">
+          <div className="modal-title-container">
+            <div className="modal-title"> Unsaved Changes </div>
+          </div>
+          <div className="save-prompt">
+            Do you want to save your preferences?
+          </div>
+          <div className="save-prompt-buttons">
+            <div className="save-prompt-button"
+            onClick={(e) => handleSavePreferences()}>
+              Save
+            </div> 
+            <div className="save-prompt-button"
+            onClick={() => handleCancelSavePreferences()}>
+              Cancel
+            </div>
+          </div>   
+        </div>
+      </div>
+      }
       <div
         className="annot-modal"
         ref={modalRef}
@@ -453,14 +508,19 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
           <>
             <div className="annot-arguments-container">
               <div className="select-annotator-container">
-                <>Selected Annotator:</>
+                Selected Annotator:
                 <select
                   className="select-annotator"
                   value={selectedAnnotator}
-                  onChange={e => setSelectedAnnotator(e.target.value)}
+                  onChange={e => {
+                    setSelectedAnnotator(e.target.value);
+                    if (isUnsaved) {
+                      setSavePromptVisible(true)
+                    }
+                  }}
                 >
                   {annotators.map((a) => (
-                    <option className="select-options" value={a.id}>{a.name}</option>
+                    <option className="select-options" value={a.id} key={a.id}>{a.name}</option>
                   ))
                   }
                 </select>
@@ -468,12 +528,16 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
               
               {annotatorIDtoForm[selectedAnnotator]}
             </div>
-            <div
-              className="annot-recommend-button"
+            {selectedAnnotator === Annotators.AMAS ? <div
+              className= "annot-recommend-button"
               onClick={handleGenerateAnnotations}
             >
               Generate annotation recommendations
+            </div>:
+            <div className= "annot-recommend-button-grey">
+              Annotation Recommendation Not Available
             </div>
+            }
           </>
         )}
 
@@ -551,5 +615,164 @@ const RecommendAnnotationModal: React.FC<RecommendAnnotationModalProps> = ({
     </>
   );
 };
+
+export const DefaultFormPreferences:{[key:string]: any} = {
+  "amas": {
+    "cutoff" : 0.1,
+    "mssc" : "TOP"
+  },
+  "example": {
+    "one": "Example String",
+    "two": 0,
+    "three": 0,
+    "four": "Select1",
+  },
+}
+
+// The preference form for AMAS
+const AMASForm = (unsavedPreferences:{[key:string]: any}, updateUnsavedPreferences: (annotator: Annotators, key:string, value:any) => void) => {
+
+  const [mssc, updateMssc] = useState<MSSC>(unsavedPreferences[Annotators.AMAS]["mssc"] as MSSC);
+  const [cutoff, updateCutoff] = useState<number>(unsavedPreferences[Annotators.AMAS]["cutoff"])
+
+  /**
+   * Handles changes to the cutoff value input field.
+   * Ensures the value stays within the valid range of 0.0 to 1.0.
+   *
+   * @param event - The change event from the number input field.
+   */
+  const handleCutoff = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let value = parseFloat(event.target.value);
+    if (value >= 0.0 && value <= 1.0) {
+      updateUnsavedPreferences(Annotators.AMAS, "cutoff", value);
+      updateCutoff(value)
+    }
+  };
+
+  /**
+   * Handles changes to the MSSC dropdown selection.
+   *
+   * @param event - The change event from the dropdown select element.
+   */
+  const handleMSSC = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    updateUnsavedPreferences(Annotators.AMAS, "mssc", event.target.value);
+    updateMssc(event.target.value as MSSC)
+  };
+
+  return (
+    <>
+      <div className="annot-argument-container">
+        <label htmlFor="cutoffInput">Cutoff Score (0.0 - 1.0):</label>
+        <input
+          id="cutoffInput"
+          type="number"
+          value={cutoff}
+          onChange={handleCutoff}
+          min="0.0"
+          max="1.0"
+          step="0.01"
+        />
+      </div>
+      <div className="annot-argument-container">
+        <label htmlFor="msscInput">
+          Match Score Selection Criteria (MSSC):
+        </label>
+        <select 
+          id="msscInput" value={mssc} onChange={handleMSSC}>
+          {Object.values(MSSC).map((value) => (
+            <option key={value} value={value}>
+              {value.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}
+
+// An example form to play around with
+// When adding properties, you will need to 
+// update the default preferences above
+const ExampleForm = (unsavedPreferences:{[key:string]: any}, updateUnsavedPreferences: (annotator: Annotators, key:string, value:any) => void) => {
+
+  enum SelectValues {
+    Select1 = "Select1",
+    Select2 = "Select2",
+    Select3 = "Select3"
+  }
+
+  const [one, setOne] = useState<string>(unsavedPreferences[Annotators.EXAMPLE]["one"]);
+  const [two, setTwo] = useState<number>(unsavedPreferences[Annotators.EXAMPLE]["two"]);
+  const [three, setThree] = useState<number>(unsavedPreferences[Annotators.EXAMPLE]["three"]);
+  const [four, setFour] = useState<SelectValues>(unsavedPreferences[Annotators.EXAMPLE]["four"] as SelectValues);
+
+  return (
+    <>
+      <div className="annot-argument-container">
+        <label htmlFor="ExampleInput1"> Example Input String </label>
+        <input
+          id = "ExampleInput1"
+          type= "string"
+          value = {one}
+          onChange = {(e) => {
+            updateUnsavedPreferences(Annotators.EXAMPLE, "one", e.target.value);
+            setOne(e.target.value);
+          }
+          }
+        />
+      </div>
+      <div className="annot-argument-container">
+        <label htmlFor="ExampleInput2"> Example Input Number </label>
+        <input
+          id = "ExampleInput2"
+          type= "number"
+          value = {two}
+          onChange = {(e) => {
+            updateUnsavedPreferences(Annotators.EXAMPLE, "two", e.target.value);
+            setTwo(parseInt(e.target.value));
+          }
+          }
+        />
+      </div>
+      <div className="annot-argument-container">
+        <label htmlFor="ExampleInput3"> Example Input Range </label>
+        <div className="slider-container">
+          <div className="slider-number">{three}</div>
+          <input
+          id = "ExampleInput3"
+          type= "range"
+          value = {three}
+          min = "0"
+          max = "100"
+          step = "1"
+          onChange = {(e) => {
+            updateUnsavedPreferences(Annotators.EXAMPLE, "three", e.target.value);
+            setThree(parseInt(e.target.value));
+          }
+          }
+          />
+        </div>
+        
+      </div>
+      <div className="annot-argument-container">
+        <label htmlFor="ExampleInput4"> Example Input Selector </label>
+        <select 
+          id="ExampleInput4" 
+          value={four} 
+          onChange={(e) => {
+            updateUnsavedPreferences(Annotators.EXAMPLE, "four", e.target.value);
+            setFour(e.target.value as SelectValues);
+          }
+        }>
+          {Object.values(SelectValues).map((value) => (
+            <option key={value} value={value}>
+              {value.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  )
+}
 
 export default RecommendAnnotationModal;


### PR DESCRIPTION
### Main Changes
- Added a new object store called settings to store a settings.json file
- Added functionality to recommendation UI to contain annotators other than AMAS
- Preferences can now be saved across user sessions

### Interactions
- When a preference has been changed, exiting the window, changing to a different annotator or generating annotations should prompt the user with a "Unsaved Preferences" prompt that asks the user to save preferences
- Currently only AMAS can generate annotations (we have no other annotators)
- When a new user session begins and they do not have a settings.json file in their user storage, one will be created with the default values

Future plans:
- Generalize how annotations are generated
- Add a separate settings window for annotator preferences
- Implement settings.json to other settings (like highlight color)

#90 Is the parent issue

All tests pass
npm run build runs successfully

